### PR TITLE
Add possibility to create a subfolder for each 1PW category

### DIFF
--- a/1P2KeePass/1P2KeePass.csproj
+++ b/1P2KeePass/1P2KeePass.csproj
@@ -43,6 +43,7 @@
       <HintPath>Newtonsoft.Json.dll</HintPath>
       <IncludeInPackage>false</IncludeInPackage>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\DateTimeExt.cs" />

--- a/1P2KeePass/1P2KeePass.csproj.user
+++ b/1P2KeePass/1P2KeePass.csproj.user
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <StartAction>Program</StartAction>
-    <StartProgram>Y:\Projects\Plugin.1P2KeePass\KeePassDistribution\KeePass.exe</StartProgram>
-    <StartWorkingDirectory>Y:\Projects\Plugin.1P2KeePass\KeePassDistribution\</StartWorkingDirectory>
+    <StartProgram>D:\Dev\git\1P2KeePass\KeePassDistribution\KeePass.exe</StartProgram>
+    <StartWorkingDirectory>D:\Dev\git\1P2KeePass\KeePassDistribution\</StartWorkingDirectory>
   </PropertyGroup>
 </Project>

--- a/1P2KeePass/Plugin/_1PasswordPifFormatProvider.cs
+++ b/1P2KeePass/Plugin/_1PasswordPifFormatProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using KeePass.DataExchange;
 using KeePassLib;
 using KeePassLib.Interfaces;
+using System.Windows.Forms;
 
 namespace _1Password2KeePass
 {
@@ -54,8 +55,14 @@ namespace _1Password2KeePass
 		public override void Import(PwDatabase storage, Stream input, IStatusLogger status)
 		{
 			status.SetText("Parsing .pif ...", LogStatusType.Info);
+            var res = MessageBox.Show("Create seperate subfolders for each 1PW category (like Logins, Accounts ...)?","Create Subfolders?",MessageBoxButtons.YesNo);
+            bool createSubfolder = false;
+            if ( res == DialogResult.Yes)
+            {
+                createSubfolder = true;
+            }
 			List<BaseRecord> baseRecords = _pifParser.Parse(input);
-			_pifImporter.Import(baseRecords, storage, status);
+			_pifImporter.Import(baseRecords, storage, status, createSubfolder);
 		}
 	}
 }


### PR DESCRIPTION
Hi,
great plugin, but I kinda liked the categories of 1password. 
So I added a option (messagebox asking... ) to create folders for each category in 1password.

Will look like this
![image](https://user-images.githubusercontent.com/4622393/40581805-c87cc656-6161-11e8-9f6c-3d454e47e236.png)

compared to 1password 
![image](https://user-images.githubusercontent.com/4622393/40581809-d8962b4a-6161-11e8-8f17-e0b9571b2034.png)

p.s.: I was unable to create a .plgx file, but putting the `_1Password2KeePass.dll` and `Newtonsoft.Json.dll` into plugin directory worked for me.